### PR TITLE
fix: deprecated property

### DIFF
--- a/edgeGw.tf
+++ b/edgeGw.tf
@@ -19,11 +19,13 @@ resource "aws_route" "internalRoute" {
 }
 
 resource "aws_eip" "ngwIp1" {
-  vpc = true
+  domain = "vpc"
+  # vpc = true
 }
 
 resource "aws_eip" "ngwIp2" {
-  vpc = true
+  domain = "vpc"
+  # vpc = true
 }
 
 resource "aws_nat_gateway" "ngw1" {


### PR DESCRIPTION
Disabled "vpc = true" and added "domain = 'vpc'" to EIP configuration